### PR TITLE
chore: Change from paste -> pastey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.81.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-paste = "1.0"
+pastey = "0.1.1"
 
 [dev-dependencies]
 itertools = "0.14"

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -14,7 +14,7 @@
 
 use std::sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 
-use paste::paste;
+use pastey::paste;
 
 macro_rules! cmsketch {
     ($( {$type:ty, $atomic:ty, $suffix:ident}, )*) => {

--- a/src/base.rs
+++ b/src/base.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use paste::paste;
+use pastey::paste;
 
 macro_rules! cmsketch {
     ($( {$type:ty, $suffix:ident}, )*) => {


### PR DESCRIPTION
As of right now, paste is unmaintained. More broadly, when running a utility like `cargo deny` to detect unmaintained dependencies, it'll complain about paste. I noticed this when using foyer in a project of mine. pastey should be API-compatible with paste, and is just a maintained fork.